### PR TITLE
Fix AZD Down Failure Caused by Deny Assignment Rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repo contains a demo for AKS which can be deployed to Azure with the [Aure 
     - When installing the above the following tools will be installed on your machine as well:
         - [GitHub CLI](https://cli.github.com)
         - [Bicep CLI](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/install)
+- [AzureCLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
 - [KubeCTL](https://kubernetes.io/docs/tasks/tools/)
 - [PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell)
 - [Helm](https://helm.sh/docs/intro/install/)

--- a/azd-hooks/postdeploy.ps1
+++ b/azd-hooks/postdeploy.ps1
@@ -1,6 +1,3 @@
 #!/usr/bin/env pwsh
 
-############################################
-# Delete custom-values.yaml
-############################################
 Remove-Item -Path custom-values.yaml -ErrorAction SilentlyContinue

--- a/azd-hooks/predeploy.ps1
+++ b/azd-hooks/predeploy.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 
-function Check-Command {
+function Assert-Command {
     param (
         [string]$command
     )
@@ -10,9 +10,9 @@ function Check-Command {
     }
 }
 
-Check-Command -command "az"
-Check-Command -command "kubectl"
-Check-Command -command "helm"
+Assert-Command -command "az"
+Assert-Command -command "kubectl"
+Assert-Command -command "helm"
 
 try {
     az aks get-credentials --resource-group ${env:AZURE_RG_NAME} --name ${env:AZURE_AKS_CLUSTERNAME} --overwrite-existing

--- a/azd-hooks/predown.ps1
+++ b/azd-hooks/predown.ps1
@@ -1,8 +1,10 @@
 #!/usr/bin/env pwsh
 
 try {
-    az group delete --name ${env:AZURE_RG_NAME} --yes
+    az tag update --resource-id /subscriptions/${env:AZURE_SUBSCRIPTION_ID}/resourceGroups/MA_${env:AZURE_MONITOR_NAME}_${env:AZURE_LOCATION}_managed --operation delete --tags azd-env-name=${env:AZURE_ENV_NAME}
+    az tag update --resource-id /subscriptions/${env:AZURE_SUBSCRIPTION_ID}/resourceGroups/MA_${env:AZURE_MONITOR_NAME}_${env:AZURE_LOCATION}_managed/providers/Microsoft.Insights/dataCollectionEndpoints/${env:AZURE_MONITOR_NAME} --operation delete --tags azd-env-name=${env:AZURE_ENV_NAME}
+    az tag update --resource-id /subscriptions/${env:AZURE_SUBSCRIPTION_ID}/resourceGroups/MA_${env:AZURE_MONITOR_NAME}_${env:AZURE_LOCATION}_managed/providers/Microsoft.Insights/dataCollectionRules/${env:AZURE_MONITOR_NAME} --operation delete --tags azd-env-name=${env:AZURE_ENV_NAME}
 } catch {
-    Write-Error "Failed to get AKS credentials: $_"
+    Write-Error "Failed to remove tags. If these tags can't be removed AZD Down will not be able to execute"
     exit 1
 }

--- a/azd-hooks/predown.ps1
+++ b/azd-hooks/predown.ps1
@@ -1,5 +1,9 @@
 #!/usr/bin/env pwsh
 
+# The AZD down command is failing due to a default deny rule set by Bicep.
+# To resolve the issue, the AZD tags have been removed from the resource with the deny assignment.
+# By doing this, the resource is no longer targeted by the AZD down command, allowing it to proceed without errors.
+# The resource group will be deleted by Azure. If the Azure Monitor Workspace is deleted, the resource group with the deny assignment will be deleted as well.
 try {
     az tag update --resource-id /subscriptions/${env:AZURE_SUBSCRIPTION_ID}/resourceGroups/MA_${env:AZURE_MONITOR_NAME}_${env:AZURE_LOCATION}_managed --operation delete --tags azd-env-name=${env:AZURE_ENV_NAME}
     az tag update --resource-id /subscriptions/${env:AZURE_SUBSCRIPTION_ID}/resourceGroups/MA_${env:AZURE_MONITOR_NAME}_${env:AZURE_LOCATION}_managed/providers/Microsoft.Insights/dataCollectionEndpoints/${env:AZURE_MONITOR_NAME} --operation delete --tags azd-env-name=${env:AZURE_ENV_NAME}

--- a/azure.yaml
+++ b/azure.yaml
@@ -5,32 +5,32 @@ hooks:
     windows:
       shell: pwsh
       continueOnError: false
-      interactive: false
+      interactive: true
       run: azd-hooks/predeploy.ps1
     posix:
       shell: pwsh
       continueOnError: false
-      interactive: false
+      interactive: true
       run: azd-hooks/predeploy.ps1
   postdeploy:
     windows:
       shell: pwsh
       continueOnError: false
-      interactive: false
+      interactive: true
       run: azd-hooks/postdeploy.ps1
     posix:
       shell: pwsh
       continueOnError: false
-      interactive: false
+      interactive: true
       run: azd-hooks/postdeploy.ps1
   predown: # This hook is executed before the deletion of the application to delete the custom-values.yaml file
     windows:
       shell: pwsh
       continueOnError: false
-      interactive: false
+      interactive: true
       run: azd-hooks/predown.ps1
     posix:
       shell: pwsh
       continueOnError: false
-      interactive: false
+      interactive: true
       run: azd-hooks/predown.ps1

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -49,3 +49,4 @@ output AZURE_REGISTRY_NAME string = acr.outputs.registryName
 output AZURE_REGISTRY_URI string = acr.outputs.loginServer
 output AZURE_RG_NAME string = rg.name
 output AZURE_AKS_CLUSTERNAME string = aks.outputs.clusterName
+output AZURE_MONITOR_NAME string = monitoring.outputs.monitorWorkspaceName

--- a/infra/modules/monitoring.bicep
+++ b/infra/modules/monitoring.bicep
@@ -59,3 +59,6 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
     principalType: 'ServicePrincipal'
   }
 }
+
+
+output monitorWorkspaceName string = monitorWorkspace.name

--- a/infra/modules/monitoring.bicep
+++ b/infra/modules/monitoring.bicep
@@ -60,5 +60,4 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   }
 }
 
-
 output monitorWorkspaceName string = monitorWorkspace.name


### PR DESCRIPTION
**Problem**
The AZD down command is failing due to a default deny rule set by Bicep. This rule blocks the deletion of certain resources, preventing the command from completing successfully.

**Solution**
To resolve the issue, the AZD tags have been removed from the resource with the deny assignment. By doing this, the resource is no longer targeted by the AZD down command, allowing it to proceed without errors.

**Changes**
Removed AZD tags from the resource affected by the deny assignment.

**Testing**
Verified that the AZD down command completes successfully after the changes.

**Impact**
This change prevents errors during the AZD down process while ensuring no unintended deletions occur.