### PR TITLE
Fix: no cached repo found

### DIFF
--- a/azd-hooks/predeploy.ps1
+++ b/azd-hooks/predeploy.ps1
@@ -64,6 +64,7 @@ try {
 
         $chaosMeshPods = kubectl get pods --namespace chaos-testing -l app.kubernetes.io/instance=chaos-mesh --no-headers
         if (-not $chaosMeshPods) {
+            helm repo update
             helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
         }
     }


### PR DESCRIPTION
When running the script on Windows you get the error:
```
Error: INSTALLATION FAILED: no cached repo found. (try 'helm repo update'): open C:\Users\MaartenD\AppData\Local\Temp\helm\repository\chaos-mesh-index.yaml: The system cannot find the file specified.
```

This is due to the following behavior of helm:
- Windows file writes and locks can be delayed slightly (especially in Temp folders).
- PowerShell scripts execute very fast, faster than I/O operations sometimes.
- Helm isn't really optimized for instant sync in these race conditions — it assumes manual human use with slight delays between commands.

Due to this added an additional `helm repo update`, this isn't the nicest solution, but works.